### PR TITLE
Fix broken asciidoc links, copyright dates

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -127,17 +127,17 @@ $ python ./betrusted-soc.py --lx-print-env > .env
 
 ## Contribution Guidelines
 
-[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v2.0%20adopted-ff69b4.svg)](CODE_OF_CONDUCT.md)
+image::https://img.shields.io/badge/Contributor%20Covenant-v2.0%20adopted-ff69b4.svg[Contributor Covenant]
 
-Please see [CONTRIBUTING](CONTRIBUTING.md) for details on
+Please see link:CONTRIBUTING.md/[CONTRIBUTING] for details on
 how to make a contribution.
 
 Please note that this project is released with a
-[Contributor Code of Conduct](CODE_OF_CONDUCT.md).
+link:CODE_OF_CONDUCT.md/[Contributor Code of Conduct].
 By participating in this project you agree to abide its terms.
 
 ## License
 
-Copyright © 2019
+Copyright © 2019 - 2020
 
-Licensed under the [CERN OHL v1.2](https://ohwr.org/project/licenses/wikis/cern-ohl-v1.2) [LICENSE](LICENSE)
+Licensed under the https://ohwr.org/project/licenses/wikis/cern-ohl-v1.2[CERN OHL v1.2] link:LICENSE[LICENSE]


### PR DESCRIPTION
Links were formatted for markdown, changed to proper asciidoc format. Also added '2020' to copyright date.