### PR TITLE
Correct betrusted_soc.py path in README.md

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -16,12 +16,12 @@ image::soc_diagram.png[]
 1. Go to https://www.xilinx.com/support/download.html and download `All OS installer Single-File Download`. Our CI system uses version 2019.2, but it has also been tested against 2020.2.
 1. Do a minimal Xilinx install to /opt/Xilinx/, and untick everything except `Design Tools / Vivado Design Suite / Vivado` and `Devices / Production Devices / 7 Series`
 1. Go to https://www.xilinx.com/member/forms/license-form.html, get a license, and place it in ~/.Xilinx/Xilinx.lic
-1. Run `./betrusted-soc.py` (or `python3 ./betrusted-soc.py`)
+1. Run `./betrusted_soc.py` (or `python3 ./betrusted-soc.py`)
 
-There's a lot of options for betrusted-soc.py. The exact command line used to build a Betrusted SoC that is
+There's a lot of options for betrusted_soc.py. The exact command line used to build a Betrusted SoC that is
 compatible with Xous as of July 2021 is:
 
-`./betrusted-soc.py -e blank.nky`
+`./betrusted_soc.py -e blank.nky`
 
 The script will expect a file called `keystore.bin` to exist in the same directory. This is the initial
 keystore, documented at https://github.com/betrusted-io/betrusted-wiki/wiki/Secure-Boot-and-KEYROM-Layout.
@@ -144,14 +144,14 @@ Open this directory in PyCharm and expand the `deps/` directory.  Then hold down
 
 Then, right-click and select `Mark directory as...` and select `Sources Root`.  The red squiggly lines should go away, and PyCharm should now be configured.
 
-When running your module from within PyCharm, you may find it useful to set environment variables.  You can use the `--lx-print-env` command.  For example: `./betrusted-soc.py --lx-print-env > pycharm.env` to create a `.env`-compatible file.  There are several PyCharm plugins that can make use of this file.
+When running your module from within PyCharm, you may find it useful to set environment variables.  You can use the `--lx-print-env` command.  For example: `./betrusted_soc.py --lx-print-env > pycharm.env` to create a `.env`-compatible file.  There are several PyCharm plugins that can make use of this file.
 
 ## Visual Studio Code integration ##
 
 Visual Studio Code needs to know where modules are.  These are specified in environment variables, which are automatically read from a .env file in your project root.  Create this file to enable `pylint` and debugging in Visual Studio Code:
 
 ```sh
-$ python ./betrusted-soc.py --lx-print-env > .env
+$ python ./betrusted_soc.py --lx-print-env > .env
 ```
 
 The analyzer will also need to know where your imports are. This would involve editing your `settings.json` file and adding a record that looks a bit like this:


### PR DESCRIPTION
It seems in 9723f045fd06b269435dc462d7f588bf3938b54c this script was renamed and the documentation wasn't updated! This fixes that.